### PR TITLE
HDA-9433 Deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
- 
+# YouTubePlayerView (Deprecated)
+
+⚠️ **Deprecation Notice
+
+Please note that the [YouTube Android Player API](https://developers.google.com/youtube/android/player) has been deprecated and is no longer recommended for use. As a result, YouTubePlayerView will also be deprecated.
+Instead, you can migrate to the [YouTube IFrame Player API](https://developers.google.com/youtube/iframe_api_reference).
+
 # What is YouTubePlayerView?
 - [YouTube Player API](https://developers.google.com/youtube/android/player/) is too old version
 <br>: Never updated from 2015/10/12


### PR DESCRIPTION
## 개요

YouTube Android Player API의 deprecation에 따라 YouTubePlayerView도 사용할 수 없으므로 Deprecated 공지를 추가합니다.